### PR TITLE
Support unordered list

### DIFF
--- a/htmlslacker/htmlslacker.py
+++ b/htmlslacker/htmlslacker.py
@@ -23,6 +23,7 @@ class HTMLSlacker(HTMLParser):
         except TypeError:
             HTMLParser.__init__(self, *args, **kwargs)
         self.skip = False
+        self.isProcessingList = False
 
         # slackified string
         self.output = ''
@@ -55,6 +56,10 @@ class HTMLSlacker(HTMLParser):
                     self.output += attr[1] + '|'
         if tag == 'style' or tag == 'script':
             self.skip = True
+        if tag == 'ul':
+            self.isProcessingList = True
+        if tag == 'li' and self.isProcessingList:
+            self.output += '• '
 
     def handle_endtag(self, tag):
         """
@@ -72,6 +77,10 @@ class HTMLSlacker(HTMLParser):
             self.output += '`'
         if tag == 'style' or tag == 'script':
             self.skip = False
+        if tag == 'ul':
+            self.isProcessingList = False
+        if tag == 'li' and self.isProcessingList:
+            self.output +='\n'
 
     def handle_data(self, data):
         """

--- a/htmlslacker/htmlslacker.py
+++ b/htmlslacker/htmlslacker.py
@@ -80,7 +80,7 @@ class HTMLSlacker(HTMLParser):
         if tag == 'ul':
             self.isProcessingList = False
         if tag == 'li' and self.isProcessingList:
-            self.output +='\n'
+            self.output += LINEBR
 
     def handle_data(self, data):
         """

--- a/test_general.py
+++ b/test_general.py
@@ -37,13 +37,15 @@ def test_link_with_target():
     assert(output == expected)
 
 def test_unordered_list():
-    html = 'Here is my cool list <ul><li>The Shining></li><li>Memento</li><li>Blade Runner</li></ul>'
-    expected = 'Here is my cool list • The Shining\n• Memento\n• Blade Runner'
+    html = 'Here is my cool list <ul><li>The Shining</li><li>Memento</li><li>Blade Runner</li></ul>'
+    expected = 'Here is my cool list • The Shining\n• Memento\n• Blade Runner\n'
     output = HTMLSlacker(html).get_output()
     assert(output == expected)
 
 def test_unordered_list_with_text_modifications():
-    html = 'Here is my cool list <ul><li>The Shining></li><li>Memento</li><li>Blade <b>Runner</b></li></ul>'
-    expected = 'Here is my cool list • The Shining\n• Me_me_nto\n• Blade *Runner*'
+    html = 'Here is my cool list <ul><li>The Shining</li><li>Memento</li><li>Blade <b>Runner</b></li></ul>'
+    expected = 'Here is my cool list • The Shining\n• Memento\n• Blade *Runner*\n'
+    print(expected)
     output = HTMLSlacker(html).get_output()
+    print(output)
     assert(output == expected)

--- a/test_general.py
+++ b/test_general.py
@@ -35,3 +35,15 @@ def test_link_with_target():
     expected = "Please click <http://xxx.com/t.html|here>"
     output = HTMLSlacker(html).get_output()
     assert(output == expected)
+
+def test_unordered_list():
+    html = 'Here is my cool list <ul><li>The Shining></li><li>Memento</li><li>Blade Runner</li></ul>'
+    expected = 'Here is my cool list • The Shining\n• Memento\n• Blade Runner'
+    output = HTMLSlacker(html).get_output()
+    assert(output == expected)
+
+def test_unordered_list_with_text_modifications():
+    html = 'Here is my cool list <ul><li>The Shining></li><li>Memento</li><li>Blade <b>Runner</b></li></ul>'
+    expected = 'Here is my cool list • The Shining\n• Me_me_nto\n• Blade *Runner*'
+    output = HTMLSlacker(html).get_output()
+    assert(output == expected)

--- a/test_general.py
+++ b/test_general.py
@@ -45,7 +45,5 @@ def test_unordered_list():
 def test_unordered_list_with_text_modifications():
     html = 'Here is my cool list <ul><li>The Shining</li><li>Memento</li><li>Blade <b>Runner</b></li></ul>'
     expected = 'Here is my cool list • The Shining\n• Memento\n• Blade *Runner*\n'
-    print(expected)
     output = HTMLSlacker(html).get_output()
-    print(output)
     assert(output == expected)


### PR DESCRIPTION
**Summary**
Running a few cases where unordered list will be convenient instead
of handling such strings using a separate converter

**Test Plan**
Unit tests which are also in this PR